### PR TITLE
Feature/superset-docker-integration

### DIFF
--- a/ETL-Airflow/Dockerfile.superset
+++ b/ETL-Airflow/Dockerfile.superset
@@ -1,0 +1,7 @@
+FROM apache/superset:latest
+
+USER root
+
+RUN pip install psycopg2-binary
+
+USER superset

--- a/ETL-Airflow/docker-compose.override.yml
+++ b/ETL-Airflow/docker-compose.override.yml
@@ -50,6 +50,30 @@ services:
       - spark-master
     networks:
       - airflow
+  superset:
+      build:
+        context: .
+        dockerfile: Dockerfile.superset
+      image: superset-custom:latest
+      container_name: superset
+      environment:
+        - SUPERSET_SECRET_KEY=your_secret_key_here
+      ports:
+      - "8088:8088"
+      volumes:
+      - superset_home:/app/superset_home
+      networks:
+      - airflow
+      command: >
+        /bin/sh -c "
+        superset db upgrade &&
+        superset fab create-admin --username admin --firstname Admin --lastname User --email admin@superset.com --password admin || true &&
+        superset init &&
+        superset run -h 0.0.0.0 -p 8088"
 
 volumes:
   spark-data:
+  superset_home:
+
+networks:
+  airflow:


### PR DESCRIPTION
As per the story [MM-93](https://trello.com/c/3Jw8LU89/93-kusuma-integrate-apache-superset-into-the-project-via-docker-compose):

- Superset is included in the Docker Compose setup and runs at http://localhost:8088/
-  Admin user is auto-created (admin/admin)
-  Superset can connect to PostgreSQL/Spark via configured database connectors
-  The custom image superset-custom:latest is built using Dockerfile.superset
-  Try to login to superset host UI
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/51cb4902-9103-4efe-8b1d-b53e3f9b7dba" />
