### PR TITLE
Feature /monitor-prod-data

### DIFF
--- a/ETL-Airflow/dags/tasks/customer_sales_report_task.py
+++ b/ETL-Airflow/dags/tasks/customer_sales_report_task.py
@@ -68,7 +68,7 @@ def m_load_customer_sales_report_task():
                                     )
         log.info("Data Frame : 'JNR_Sales_Products' is built") 
 
-        # Processing Node : JNR_Data - Joins data from JNR_Sales_Products and SQ_Shortcut_To_Customers dataframes
+        # Processing Node : Joins JNR_Sales_Products with SQ_Shortcut_To_Customers on CUSTOMER_ID using a left join
         JNR_sales_Data = JNR_Sales_Products \
                                     .join(
                                          SQ_Shortcut_To_Customers,
@@ -100,7 +100,7 @@ def m_load_customer_sales_report_task():
         # Define a window to rank all rows globally by SALE_AMOUNT in descending order
         window_spec = Window.orderBy(col("SALE_AMOUNT").desc())
                 
-        # Processing Node: Loyalty_Tier - Apply percent_rank window function to segment customers by their spending
+        # Processing Node: EXP_Loyalty_Tier - Apply percent_rank window function to segment customers by their spending
         EXP_Loyalty_Tier = JNR_sales_Data \
                                 .withColumn("percent_rank", percent_rank()
                                 .over(window_spec)) \

--- a/ETL-Airflow/dags/tasks/customer_sales_report_task.py
+++ b/ETL-Airflow/dags/tasks/customer_sales_report_task.py
@@ -9,8 +9,8 @@ def m_load_customer_sales_report_task():
     try:
         spark = create_session()
 
-        # Processing Node : SQ_Shortcut_To_Sales - Reads data from 'raw.sales' table
-        SQ_Shortcut_To_Sales  = read_from_postgres(spark, "raw.sales")\
+        # Processing Node : SQ_Shortcut_To_Sales - Reads data from 'raw.sales_pre' table
+        SQ_Shortcut_To_Sales  = read_from_postgres(spark, "raw.sales_pre")\
                                         .select(
                                             col("SALE_ID"),
                                             col("CUSTOMER_ID"),
@@ -22,8 +22,8 @@ def m_load_customer_sales_report_task():
                                         )
         log.info("Data Frame: 'SQ_Shortcut_To_Sales' is built")
 
-        # Processing Node : SQ_Shortcut_To_Products - Reads data from 'raw.products' table
-        SQ_Shortcut_To_Products =read_from_postgres(spark, "raw.products")\
+        # Processing Node : SQ_Shortcut_To_Products - Reads data from 'raw.products_pre' table
+        SQ_Shortcut_To_Products =read_from_postgres(spark, "raw.products_pre")\
                                         .select(
                                             col("PRODUCT_ID"),
                                             col("PRODUCT_NAME"),
@@ -32,8 +32,8 @@ def m_load_customer_sales_report_task():
                                         )
         log.info("Data Frame: 'SQ_Shortcut_To_Products' is built")
 
-        # Processing Node : SQ_Shortcut_To_Customers - Reads data from 'raw.customers' table
-        SQ_Shortcut_To_Customers = read_from_postgres(spark, "raw.customers") \
+        # Processing Node : SQ_Shortcut_To_Customers - Reads data from 'raw.customers_pre' table
+        SQ_Shortcut_To_Customers = read_from_postgres(spark, "raw.customers_pre") \
                                                 .select(
                                                     col("CUSTOMER_ID"),
                                                     col("NAME").alias("CUSTOMER_NAME"),

--- a/ETL-Airflow/dags/tasks/ingestion_task.py
+++ b/ETL-Airflow/dags/tasks/ingestion_task.py
@@ -25,7 +25,7 @@ def m_ingest_data_into_suppliers():
          # Convert extracted JSON data to Spark DataFrame
         suppliers_df = spark.createDataFrame(data)
 
-    # Normalize column names: trim, uppercase, and replace spaces with underscores
+        # Normalize column names (supplier_id, supplier_name, contact_details, region): trim, uppercase, and replace spaces with underscores
         suppliers_df = normalize_column_names(suppliers_df)
             
         suppliers_df_tgt = suppliers_df \
@@ -84,7 +84,7 @@ def m_ingest_data_into_products():
         # Convert extracted JSON data to Spark DataFrame
         products_df = spark.createDataFrame(data)
 
-        # Normalize column names: trim, uppercase, and replace spaces with underscores
+        # Normalize column names (product_id, product_name, category, selling_price, cost_price, stock_quantity, reorder_level, supplier_id): trim, uppercase, and replace spaces with underscores
         products_df = normalize_column_names(products_df)
 
         products_df_tgt = products_df \
@@ -146,7 +146,7 @@ def m_ingest_data_into_customers():
         data = extractor.extract_data()
         customers_df = spark.createDataFrame(data)
 
-        # Normalize column names: trim, uppercase, and replace spaces with underscores
+#       Normalize column names (customer_id, name, city, email, phone_number): trim, uppercase, and replace spaces with underscores
         customers_df = normalize_column_names(customers_df)
 
         customers_df_tgt=customers_df \
@@ -211,7 +211,7 @@ def m_ingest_data_into_sales():
         # Load sales data from GCS
         sales_df =spark.read.csv(gcs_path, header=True, inferSchema=True)
 
-        # Rename columns to match schema standards (uppercase), and select the required columns
+        # Normalize column names (sale_id, customer_id, product_id, sale_date, quantity, discount, shipping_cost, order_status, payment_mode): trim, uppercase, and replace spaces with underscores
         sales_df = normalize_column_names(sales_df)
             
         sales_df_tgt = sales_df \

--- a/ETL-Airflow/dags/tasks/ingestion_task.py
+++ b/ETL-Airflow/dags/tasks/ingestion_task.py
@@ -26,6 +26,11 @@ def m_ingest_data_into_suppliers():
         suppliers_df = spark.createDataFrame(data)
 
         # Normalize column names (supplier_id, supplier_name, contact_details, region): trim, uppercase, and replace spaces with underscores
+        suppliers_df=suppliers_df \
+                            .withColumnRenamed("supplier_id", "SUPPLIER_ID") \
+                            .withColumnRenamed("supplier_name", "SUPPLIER_NAME") \
+                            .withColumnRenamed("contact_details", "CONTACT_DETAILS") \
+                            .withColumnRenamed("region", "REGION")
         suppliers_df = normalize_column_names(suppliers_df)
             
         suppliers_df_tgt = suppliers_df \
@@ -85,6 +90,15 @@ def m_ingest_data_into_products():
         products_df = spark.createDataFrame(data)
 
         # Normalize column names (product_id, product_name, category, selling_price, cost_price, stock_quantity, reorder_level, supplier_id): trim, uppercase, and replace spaces with underscores
+        products_df=products_df \
+                        .withColumnRenamed("product_id", "PRODUCT_ID") \
+                        .withColumnRenamed("product_name", "PRODUCT_NAME") \
+                        .withColumnRenamed("category", "CATEGORY") \
+                        .withColumnRenamed("selling_price", "SELLING_PRICE") \
+                        .withColumnRenamed( "cost_price","COST_PRICE") \
+                        .withColumnRenamed("stock_quantity", "STOCK_QUANTITY") \
+                        .withColumnRenamed("reorder_level", "REORDER_LEVEL") \
+                        .withColumnRenamed("supplier_id", "SUPPLIER_ID")
         products_df = normalize_column_names(products_df)
 
         products_df_tgt = products_df \
@@ -147,6 +161,12 @@ def m_ingest_data_into_customers():
         customers_df = spark.createDataFrame(data)
 
 #       Normalize column names (customer_id, name, city, email, phone_number): trim, uppercase, and replace spaces with underscores
+        customers_df=customers_df \
+                        .withColumnRenamed("customer_id", "CUSTOMER_ID") \
+                        .withColumnRenamed("name", "NAME") \
+                        .withColumnRenamed("city", "CITY") \
+                        .withColumnRenamed("email", "EMAIL") \
+                        .withColumnRenamed("phone_number", "PHONE_NUMBER")
         customers_df = normalize_column_names(customers_df)
 
         customers_df_tgt=customers_df \
@@ -212,6 +232,16 @@ def m_ingest_data_into_sales():
         sales_df =spark.read.csv(gcs_path, header=True, inferSchema=True)
 
         # Normalize column names (sale_id, customer_id, product_id, sale_date, quantity, discount, shipping_cost, order_status, payment_mode): trim, uppercase, and replace spaces with underscores
+        sales_df = sales_df \
+                    .withColumnRenamed("sale_id", "SALE_ID") \
+                    .withColumnRenamed("customer_id", "CUSTOMER_ID") \
+                    .withColumnRenamed("product_id", "PRODUCT_ID") \
+                    .withColumnRenamed("sale_date", "SALE_DATE") \
+                    .withColumnRenamed("quantity", "QUANTITY") \
+                    .withColumnRenamed("discount", "DISCOUNT") \
+                    .withColumnRenamed("shipping_cost", "SHIPPING_COST") \
+                    .withColumnRenamed("order_status", "ORDER_STATUS") \
+                    .withColumnRenamed("payment_mode", "PAYMENT_MODE")
         sales_df = normalize_column_names(sales_df)
             
         sales_df_tgt = sales_df \

--- a/ETL-Airflow/dags/tasks/product_performance_task.py
+++ b/ETL-Airflow/dags/tasks/product_performance_task.py
@@ -8,16 +8,16 @@ def m_load_product_performance():
     try:
         spark = create_session()
 
-        # Processing Node : SQ_Shortcut_To_sales - Reads data from 'raw.sales' table
-        SQ_Shortcut_To_sales = read_from_postgres(spark, "raw.sales")\
+        # Processing Node : SQ_Shortcut_To_sales - Reads data from 'raw.sales_pre' table
+        SQ_Shortcut_To_sales = read_from_postgres(spark, "raw.sales_pre")\
                                 .select(
                                         col("PRODUCT_ID"),
                                         col("QUANTITY")
                                 )
         log.info("Data Frame : 'SQ_Shortcut_To_sales' is built")
 
-       # Processing Node : SQ_Shortcut_To_Products - Reads data from 'raw.products' table
-        SQ_Shortcut_To_Products = read_from_postgres(spark, "raw.products")\
+       # Processing Node : SQ_Shortcut_To_Products - Reads data from 'raw.products_pre' table
+        SQ_Shortcut_To_Products = read_from_postgres(spark, "raw.products_pre")\
                                     .select(
                                             col("PRODUCT_ID"), 
                                             col("PRODUCT_NAME"), 

--- a/ETL-Airflow/dags/tasks/product_performance_task.py
+++ b/ETL-Airflow/dags/tasks/product_performance_task.py
@@ -95,7 +95,7 @@ def m_load_product_performance():
                                     .withColumnRenamed("agg_PROFIT", "PROFIT")\
                                     .withColumnRenamed("Stock_Level_Status", "STOCK_LEVEL_STATUS")
 
-        # Processing Node : Shortcut_To_Supplier_Performance_Tgt - Selects and arranges final columns as per target table schema
+        # Processing Node : Shortcut_To_product_Performance_Tgt - Selects and arranges final columns as per target table schema
         Shortcut_To_product_performance_Tgt = product_performance\
                                                     .select(
                                                         col("PRODUCT_ID"),

--- a/ETL-Airflow/dags/tasks/supplier_performance_task.py
+++ b/ETL-Airflow/dags/tasks/supplier_performance_task.py
@@ -10,8 +10,8 @@ def m_load_suppliers_performance():
     try:
         spark = create_session()
 
-        # Processing Node : SQ_Shortcut_To_Sales - Reads data from 'raw.sales' table
-        SQ_Shortcut_To_Sales = read_from_postgres(spark, "raw.sales")\
+        # Processing Node : SQ_Shortcut_To_Sales - Reads data from 'raw.sales_pre' table
+        SQ_Shortcut_To_Sales = read_from_postgres(spark, "raw.sales_pre")\
                                 .select(
                                     col("PRODUCT_ID"),
                                     col("QUANTITY"),
@@ -19,8 +19,8 @@ def m_load_suppliers_performance():
                                 )
         log.info("Data Frame : 'SQ_Shortcut_To_Sales' is built")
 
-        # Processing Node : SQ_Shortcut_To_Products - Reads data from 'raw.products' table
-        SQ_Shortcut_To_Products = read_from_postgres(spark, "raw.products")\
+        # Processing Node : SQ_Shortcut_To_Products - Reads data from 'raw.products_pre' table
+        SQ_Shortcut_To_Products = read_from_postgres(spark, "raw.products_pre")\
                                         .select(
                                             col("PRODUCT_ID"),
                                             col("SUPPLIER_ID"),
@@ -29,8 +29,8 @@ def m_load_suppliers_performance():
                                         )
         log.info("Data Frame : 'SQ_Shortcut_To_Products' is built")
 
-        # Processing Node : SQ_Shortcut_To_Suppliers - Reads data from 'raw.suppliers' table
-        SQ_Shortcut_To_Suppliers = read_from_postgres(spark, "raw.suppliers")\
+        # Processing Node : SQ_Shortcut_To_Suppliers - Reads data from 'raw.suppliers_pre' table
+        SQ_Shortcut_To_Suppliers = read_from_postgres(spark, "raw.suppliers_pre")\
                                         .select(
                                             col("SUPPLIER_ID"),
                                             col("SUPPLIER_NAME")

--- a/server/server.py
+++ b/server/server.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from dotenv import load_dotenv
 from os import environ as env
 from my_secrets import PASSWORD
+from datetime import datetime
 
 
 from utils import (
@@ -48,7 +49,7 @@ def get_latest_file_from_gcs(file_keyword: str):
     
         client = get_gcs_client()
         bucket = client.get_bucket(GCS_BUCKET_NAME)
-        today_str = "20250322"
+        today_str = datetime.today().strftime("%Y%m%d")
         blob_path = f"{today_str}/{file_keyword}_{today_str}.csv"
         blob = bucket.blob(blob_path)
 


### PR DESCRIPTION
As per the story [MM-161](https://trello.com/c/xRxWN9zY/161-kusuma-monitoring-the-production-data-for-3-successive-days?filter=member:bottakusumasuvarnalakshmi):

- Clean up the Data from all existing Tables.
- Move the Environment to PROD by Generalising the Dates to use the live date
- The files would be available from 10:00 AM. Make sure Your pipeline runs at 11:30 AM Daily.
- In case of the Job failure, Raise a Bug saying : Pipeline Failed : Metamorph with the Description: Job failed with the Error : (Paste the Error). And try to work on it before the next day (At high Priority)



<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1d36aa4c-3f57-4ac5-8124-e1d9306c7659" />
